### PR TITLE
[CHG]将类型定义更改为兼容的3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ tox==3.25.0
 pytest==7.0.1
 pytest-cov==3.0.0
 pytest-benchmark[histogram]==3.4.1
-ujson==5.1.0
+ujson

--- a/src/cache3/disk.py
+++ b/src/cache3/disk.py
@@ -30,8 +30,8 @@ Number: Type = Union[int, float]
 TG: Type = Optional[str]
 Time: Type = Optional[float]
 PATH: Type = Union[Path, str]
-QY: Type = Callable[[Any, ...], Cursor]
-ROW: Type = Optional[Tuple[Any, ...]]
+QY: Type = Callable[[Any], Cursor]
+ROW: Type = Optional[Tuple[Any]]
 
 # SQLite pragma configs
 PRAGMAS: Dict[str, Union[str, int]] = {

--- a/tests/test_disk_cache/test_disk_simplecache.py
+++ b/tests/test_disk_cache/test_disk_simplecache.py
@@ -3,7 +3,7 @@
 # DATE: 2022/1/20
 # Author: clarkmonkey@163.com
 
-from typing import *
+from typing import NoReturn
 
 
 def test_simplecache() -> NoReturn:


### PR DESCRIPTION
The `NoReturn` and `...` in typing is not supported by python3.6 .