### PR TITLE
cannot set timeout = None when create DiskCache instance

### DIFF
--- a/src/cache3/validate.py
+++ b/src/cache3/validate.py
@@ -35,6 +35,9 @@ class NumberValidate(Validator):
         self.maxvalue: Number = maxvalue
 
     def validate(self, value) -> NoReturn:
+        
+        if value is None:
+            return
 
         if not isinstance(value, (int, float)):
             raise TypeError(f'Expected {value!r} to be an int or float')


### PR DESCRIPTION
Setting timeout to None when creating a DiskCache throws an exception.

```python
from cache3 import DiskCache

cache = DiskCache(timeout=None)

-- exception--
Traceback (most recent call last):
  File "/Users/Aris/Workspace/proxy/file.py", line 7, in <module>
    cache3.DiskCache(timeout=None)
  File "/Users/Aris/env/python/cache3.env/lib/python3.9/site-packages/cache3/disk.py", line 193, in __init__
    super(SimpleDiskCache, self).__init__(*args, **kwargs)
  File "/Users/Aris/env/python/cache3.env/lib/python3.9/site-packages/cache3/base.py", line 76, in __init__
    self.timeout: Time = timeout
  File "/Users/Aris/env/python/cache3.env/lib/python3.9/site-packages/cache3/validate.py", line 22, in __set__
    validate_value: Any = self.validate(value)
  File "/Users/Aris/env/python/cache3.env/lib/python3.9/site-packages/cache3/validate.py", line 40, in validate
    raise TypeError(f'Expected {value!r} to be an int or float')
TypeError: Expected None to be an int or float
```