### PR TITLE
fix #19: Cache cache.keys(tag="tag") return empty iterator and unit test failure 

### DIFF
--- a/src/cache3/memory.py
+++ b/src/cache3/memory.py
@@ -321,7 +321,8 @@ class Cache:
                     yield m[0], m[1], _tag
         else:
             cache = self._caches[tag]
-            return cache.items()
+            for m in cache.items():
+                yield m[0], m[1], tag
 
     def keys(self, tag: TG = empty) -> Iterable[Any]:
         if tag is empty:
@@ -330,7 +331,8 @@ class Cache:
                     yield k
         else:
             cache = self._caches[tag]
-            return cache.keys()
+            for k in cache.keys():
+                yield k
     
     def values(self, tag: TG = empty) -> Iterable[Any]:
         if tag is empty:
@@ -339,7 +341,8 @@ class Cache:
                     yield v
         else:
             cache = self._caches[tag]
-            return cache.values()
+            for v in cache.values():
+                yield v
 
     def __len__(self) -> int:
         return sum(len(cache) for cache in self._caches.values())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,7 +33,7 @@ class CacheApiMixin:
         
         # items
         for tag in cases:
-            for key, value in self.cache.items(tag):
+            for key, value, *rest in self.cache.items(tag):
                 assert key == value[::-1]
 
 


### PR DESCRIPTION
yield and return both used in [src/cache3/memory.py#L324](https://github.com/StKali/cache3/blob/fe08ba44eb4e6ae3fefbced88893559d4673992a/src/cache3/memory.py#L324) which caused issue, fix it with simple iterate. 
also fix unit test failure since disk cache returns tuple with 2 elements but memory returns 3.